### PR TITLE
Changes in SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Python MindsDB SDK
-It enables you to connect to a midnsDB server from python using HTTP API.
+It enables you to connect to a MidnsDB server from python using HTTP API.
 
 ## Install
 ```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It enables you to connect to a midnsDB server from python using HTTP API.
 pip install mindsdb_sdk
 ```
 
-## Example 
+## Example
 
 Connect:
 ```python
@@ -77,6 +77,10 @@ model = project.create_model(
 )
 
 ```
+
+More examples in [Google colab notebook](
+https://colab.research.google.com/drive/1QouwAR3saFb9ffthrIs1LSH5COzyQa11#scrollTo=k6IbwsKRPQCR
+)
 
 ## API documentation
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Python MindsDB SDK
-It enables you to connect to a midnsDB server and use it in a similar way to mindsb_native.
+It enables you to connect to a midnsDB server from python using HTTP API.
 
 ## Install
 ```

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ server = mindsdb_sdk.connect('http://127.0.0.1:47334')
 # Connect to cloud server
 
 server = mindsdb_sdk.connect(email='a@b.com', password='-')
-server = mindsdb_sdk.connect('https://cloud.mindsdb.com', email='a@b.com', password='-')
+server = mindsdb_sdk.connect('https://cloud.mindsdb.com', login='a@b.com', password='-')
 
 # Connect to MindsDB Pro
 
-server = mindsdb_sdk.connect('http://<YOUR_INSTANCE_IP>', email='a@b.com', password='-', is_managed: True)
+server = mindsdb_sdk.connect('http://<YOUR_INSTANCE_IP>', login='a@b.com', password='-', is_managed=True)
 
 ```
 

--- a/mindsdb_sdk/__init__.py
+++ b/mindsdb_sdk/__init__.py
@@ -4,12 +4,12 @@ from mindsdb_sdk.__about__ import __package_name__ as name, __version__
 from .server import Server
 
 
-def connect(url: str = None, email: str = None, password: str = None, is_managed: bool = False) -> Server:
+def connect(url: str = None, login: str = None, password: str = None, is_managed: bool = False) -> Server:
     """
     Create connection to mindsdb server
 
     :param url: url to mindsdb server
-    :param email: user email to login (for cloud version)
+    :param login: user login, for cloud version it contents email
     :param password: user password to login (for cloud version)
     :param is_managed: whether or not the URL points to a managed instance
     :return: Server object
@@ -26,20 +26,20 @@ def connect(url: str = None, email: str = None, password: str = None, is_managed
 
     Connect to cloud server
 
-    >>> server = mindsdb_sdk.connect(email='a@b.com', password='-')
-    >>> server = mindsdb_sdk.connect('https://cloud.mindsdb.com', email='a@b.com', password='-')
+    >>> server = mindsdb_sdk.connect(login='a@b.com', password='-')
+    >>> server = mindsdb_sdk.connect('https://cloud.mindsdb.com', login='a@b.com', password='-')
 
     Connect to MindsDB pro
 
-    >>> server = mindsdb_sdk.connect('http://<YOUR_INSTANCE_IP>', email='a@b.com', password='-', is_managed=True)
+    >>> server = mindsdb_sdk.connect('http://<YOUR_INSTANCE_IP>', login='a@b.com', password='-', is_managed=True)
 
     """
     if url is None:
-        if email is not None:
+        if login is not None:
             # default is cloud
             url = 'https://cloud.mindsdb.com'
         else:
             # is local
             url = 'http://127.0.0.1:47334'
 
-    return Server(url=url, email=email, password=password, is_managed=is_managed)
+    return Server(url=url, login=login, password=password, is_managed=is_managed)

--- a/mindsdb_sdk/connectors/rest_api.py
+++ b/mindsdb_sdk/connectors/rest_api.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 
 def _try_relogin(fnc):
-    wraps(fnc)
+    @wraps(fnc)
     def wrapper(self, *args, **kwargs):
         try:
             return fnc(self, *args, **kwargs)
@@ -24,15 +24,15 @@ def _try_relogin(fnc):
 
 
 class RestAPI:
-    def __init__(self, url=None, email=None, password=None, is_managed=False):
+    def __init__(self, url=None, login=None, password=None, is_managed=False):
 
         self.url = url
-        self.email = email
+        self.username = login
         self.password = password
         self.is_managed = is_managed
         self.session = requests.Session()
 
-        if email is not None:
+        if login is not None:
             self.login()
 
     def login(self):
@@ -40,9 +40,9 @@ class RestAPI:
         url = self.url + login_endpoint
         json = {'password': self.password}
         if self.is_managed:
-            json['username'] = self.email
+            json['username'] = self.username
         else:
-            json['email'] = self.email
+            json['email'] = self.username
         r = self.session.post(url, json=json)
         r.raise_for_status()
 

--- a/mindsdb_sdk/database.py
+++ b/mindsdb_sdk/database.py
@@ -25,8 +25,8 @@ class Database:
 
     Filter and limit
 
-    >>> table.filter(a=1, b='2')
-    >>> table.limit(3)
+    >>> table = table.filter(a=1, b='2')
+    >>> table = table.limit(3)
 
     Get content of table as dataframe. At that moment query will be sent on server and executed
 

--- a/mindsdb_sdk/model.py
+++ b/mindsdb_sdk/model.py
@@ -4,7 +4,7 @@ from typing import List, Union
 
 import pandas as pd
 
-from mindsdb_sql.parser.dialects.mindsdb import RetrainPredictor, AdjustPredictor
+from mindsdb_sql.parser.dialects.mindsdb import RetrainPredictor, FinetunePredictor
 from mindsdb_sql.parser.ast import Identifier, Select, Star, Join, Update, Describe, Constant
 from mindsdb_sql import parse_sql
 from mindsdb_sql.planner.utils import query_traversal
@@ -115,21 +115,21 @@ class Model:
         self.data = model.data
         return self.data
 
-    def adjust(self,
+    def finetune(self,
                query: Union[str, Query] = None,
                database: str = None,
                options: dict = None,
                engine: str = None) -> Union[Model, ModelVersion]:
         """
-        Call adjust of the model
+        Call finetune of the model
 
-        :param query: sql string or Query object to get data for adjusting, optional
-        :param database: database to get data for adjusting, optional
-        :param options: parameters for adjusting model, optional
+        :param query: sql string or Query object to get data for fine-tuning, optional
+        :param database: database to get data for fine-tuning, optional
+        :param options: parameters for fine-tuning model, optional
         :param engine: ml engine, optional
         :return: Model object
         """
-        return self._retrain(ast_class=AdjustPredictor,
+        return self._retrain(ast_class=FinetunePredictor,
                              query=query, database=database,
                              options=options, engine=engine)
 

--- a/mindsdb_sdk/project.py
+++ b/mindsdb_sdk/project.py
@@ -93,8 +93,8 @@ class Project:
 
     Getting data:
 
-    >>> view.filter(a=1, b=2)
-    >>> view.limit(100)
+    >>> view = view.filter(a=1, b=2)
+    >>> view = view.limit(100)
     >>> df = view.fetch()
 
     Drop view:

--- a/mindsdb_sdk/project.py
+++ b/mindsdb_sdk/project.py
@@ -346,7 +346,7 @@ class Project:
             for item in df.to_dict('records')
         ]
 
-    def create_model(self, name: str, predict: str, engine: str = None,
+    def create_model(self, name: str, predict: str = None, engine: str = None,
                      query: Union[str, Query] = None, database: str = None,
                      options: dict = None, timeseries_options: dict = None) -> Model:
         """
@@ -372,11 +372,15 @@ class Project:
         if database is not None:
             database = Identifier(database)
 
+        if predict is not None:
+            targets = [Identifier(predict)]
+        else:
+            targets = None
         ast_query = CreatePredictor(
             name=Identifier(name),
             query_str=query,
             integration_name=database,
-            targets=[Identifier(predict)],
+            targets=targets,
         )
 
         if timeseries_options is not None:
@@ -395,7 +399,7 @@ class Project:
             options = {}
         if engine is not None:
             options['engine'] = engine
-
+        ast_query.using = options
         df = self.query(ast_query.to_string()).fetch()
         if len(df) > 0:
             data = dict(df.iloc[0])

--- a/mindsdb_sdk/project.py
+++ b/mindsdb_sdk/project.py
@@ -195,11 +195,11 @@ class Project:
 
     Model managing
 
-    Adjusting
+    Fine-tuning
 
-    >>> model.adjust(query)
-    >>> model.adjust('select * from demo_data.house_sales', database='example_db')
-    >>> model.adjust(query, params={'x': 2})
+    >>> model.finetune(query)
+    >>> model.finetune('select * from demo_data.house_sales', database='example_db')
+    >>> model.finetune(query, params={'x': 2})
 
     Retraining
 

--- a/mindsdb_sdk/project.py
+++ b/mindsdb_sdk/project.py
@@ -493,7 +493,7 @@ class Project:
         else:
             raise RuntimeError("Several jobs with the same name")
 
-    def create_job(self, name: str, query_str:str,
+    def create_job(self, name: str, query_str: str,
                    start_at: dt.datetime = None, end_at: dt.datetime = None,
                    repeat_str: str = None) -> Union[Job, None]:
         """

--- a/mindsdb_sdk/query.py
+++ b/mindsdb_sdk/query.py
@@ -1,3 +1,5 @@
+import copy
+
 import pandas as pd
 
 from mindsdb_sql.parser.ast import Select, Star, Identifier, Constant
@@ -57,8 +59,11 @@ class Table(Query):
 
         :param kwargs: filter
         """
-        self._filters.update(kwargs)
-        self._update_query()
+        # creates new object
+        query = copy.deepcopy(self)
+        query._filters.update(kwargs)
+        query._update_query()
+        return query
 
     def limit(self, val: int):
         """
@@ -66,8 +71,10 @@ class Table(Query):
 
         :param val: limit size
         """
-        self._limit = val
-        self._update_query()
+        query = copy.deepcopy(self)
+        query._limit = val
+        query._update_query()
+        return query
 
     def _update_query(self):
         ast_query = Select(

--- a/mindsdb_sdk/server.py
+++ b/mindsdb_sdk/server.py
@@ -58,8 +58,8 @@ class Server:
 
     """
 
-    def __init__(self, url: str = None, email: str = None, password: str = None, is_managed: bool = False):
-        self.api = RestAPI(url, email, password, is_managed)
+    def __init__(self, url: str = None, login: str = None, password: str = None, is_managed: bool = False):
+        self.api = RestAPI(url, login, password, is_managed)
 
     def __repr__(self):
         return f'{self.__class__.__name__}({self.api.url})'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests
 pandas == 1.3.5
-mindsdb-sql >= 0.4.10, < 0.5.0
+mindsdb-sql >= 0.5.0, < 0.6.0

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -420,7 +420,7 @@ class Test:
 
         # create from table
         table1 = database.get_table('t1')
-        table1.filter(b=2)
+        table1 = table1.filter(b=2)
         table3 = database.create_table('t3', table1)
         check_sql_call(mock_post, f'create table {database.name}.t3 (SELECT * FROM t1 WHERE b = 2)')
 
@@ -431,8 +431,8 @@ class Test:
     def check_table(self, table, mock_post):
         response_mock(mock_post, pd.DataFrame([{'x': 'a'}]))
 
-        table.filter(a=3, b='2')
-        table.limit(3)
+        table = table.filter(a=3, b='2')
+        table = table.limit(3)
         table.fetch()
 
         check_sql_call(mock_post, f'SELECT * FROM {table.name} WHERE (a = 3) AND (b = \'2\') LIMIT 3')

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -57,7 +57,7 @@ class Test:
     @patch('requests.Session.post')
     def test_flow(self, mock_post):
 
-        server = mindsdb_sdk.connect(email='a@b.com')
+        server = mindsdb_sdk.connect(login='a@b.com')
 
         # check login
         call_args = mock_post.call_args
@@ -113,7 +113,7 @@ class Test:
     def test_managed_login(self, mock_post):
 
         mindsdb_sdk.connect(
-            'http://instance_url', email='a@b.com', password='test_pass', is_managed=True)
+            'http://instance_url', login='a@b.com', password='test_pass', is_managed=True)
 
         # check login
         call_args = mock_post.call_args

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -221,7 +221,7 @@ class Test:
         )
         check_sql_call(
             mock_post,
-            f'CREATE PREDICTOR m2 FROM example_db (select * from t1) PREDICT price ORDER BY date GROUP BY a, b WINDOW 10 HORIZON 2'
+            f'CREATE PREDICTOR m2 FROM example_db (select * from t1) PREDICT price ORDER BY date GROUP BY a, b WINDOW 10 HORIZON 2 USING module="LightGBM", `engine`="lightwood"'
         )
         assert model.name == 'm2'
         self.check_model(model, database)

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -334,16 +334,16 @@ class Test:
             pd.DataFrame([{'NAME': 'm1', 'VERSION': 2, 'STATUS': 'complete'}])
         )
 
-        model.adjust(query, options={'x': 2})
+        model.finetune(query, options={'x': 2})
         check_sql_call(
             mock_post,
-            f'ADJUST {model.project.name}.{model_name} FROM {query.database} ({query.sql})  USING x=2'
+            f'Finetune {model.project.name}.{model_name} FROM {query.database} ({query.sql})  USING x=2'
         )
 
-        model.adjust('select a from t1', database='d1')
+        model.finetune('select a from t1', database='d1')
         check_sql_call(
             mock_post,
-            f'ADJUST {model.project.name}.{model_name} FROM d1 (select a from t1)'
+            f'Finetune {model.project.name}.{model_name} FROM d1 (select a from t1)'
         )
 
         model.retrain(query, options={'x': 2})

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -318,14 +318,14 @@ class Test:
         query = database.query('select a from t1')
         pred_df = model.predict(query, params={'x': '1'})
 
-        check_sql_call(mock_post, f'SELECT t.a FROM t1 as t JOIN {model.project.name}.{model_name} USING x="1"')
+        check_sql_call(mock_post, f'SELECT m.* FROM (SELECT a FROM t1) JOIN {model.project.name}.{model_name} AS m USING x="1"')
         assert (pred_df == pd.DataFrame(data_out)).all().bool()
 
         # time series prediction
         query = database.query('select * from t1 where type="house" and saledate>latest')
         model.predict(query)
 
-        check_sql_call(mock_post, f"SELECT * FROM t1 as t JOIN {model.project.name}.{model_name} WHERE (t.type = 'house') AND (t.saledate > LATEST)")
+        check_sql_call(mock_post, f"SELECT m.* FROM (SELECT * FROM t1 WHERE (type = 'house') AND (saledate > LATEST)) JOIN {model.project.name}.{model_name} AS m")
         assert (pred_df == pd.DataFrame(data_out)).all().bool()
 
         # -----------  model managing  --------------


### PR DESCRIPTION
Changes:
- Adapted to syntax change adjust -> finetune
- .filter() and .limit() methods return new object of query with applied changes. 
  - Here table1 new object with filter and table0 keeps unchanged: 
   `table1 = table0.filter(a=2)` 
- changed parameter in connect: email -> login
- Failback for managed instance connect:
  - In case if user is connecting to managed instance with managed=False and is having error: SDK tries to connect with managed=False
- disabled injection of join in prediction by query:
  - all queries are wrapped to `select * from (<input query>) join model` now 
- Fix for using huggingface model
 