### PR TITLE
[PR] quick fix to the parameters passed to connect() in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ server = mindsdb_sdk.connect('http://127.0.0.1:47334')
 
 ```python
 import mindsdb_sdk
-server = mindsdb_sdk.connect(email='a@b.com', password='-')
+server = mindsdb_sdk.connect(login='a@b.com', password='-')
 server = mindsdb_sdk.connect('https://cloud.mindsdb.com', login='a@b.com', password='-')
 ```
 


### PR DESCRIPTION
A very quick fix to correct the use of the `connect()` function in the README. The parameter is passed previously was `email`, while it should be `login`.