### PR TITLE
[fix] index is not included when storing a pandas DF

### DIFF
--- a/mindsdb_sdk/connectors/rest_api.py
+++ b/mindsdb_sdk/connectors/rest_api.py
@@ -124,7 +124,7 @@ class RestAPI:
 
         # convert to file
         fd = io.BytesIO()
-        df.to_csv(fd)
+        df.to_csv(fd, index=False)
         fd.seek(0)
 
         url = self.url + f'/api/files/{name}'


### PR DESCRIPTION
Currently this is a problem if users upload then do `select *` without verifying data first, as the `.to_csv()` method will silently insert the index as a new feature, which will be easy to overfit/memorize on if the model is big enough.