### PR TITLE
Server info

### DIFF
--- a/mindsdb_sdk/connectors/rest_api.py
+++ b/mindsdb_sdk/connectors/rest_api.py
@@ -140,3 +140,10 @@ class RestAPI:
             }
         )
         _raise_for_status(r)
+
+    def status(self) -> dict:
+
+        r = self.session.get(self.url + f'/api/status')
+        _raise_for_status(r)
+
+        return r.json()

--- a/mindsdb_sdk/server.py
+++ b/mindsdb_sdk/server.py
@@ -51,6 +51,16 @@ class Server(Project):
         self.ml_handlers = Handlers(self.api, 'ml')
         self.data_handlers = Handlers(self.api, 'data')
 
+    def status(self) -> dict:
+        """
+        Get server information. It could content version
+        Example of getting version for local:
+        >>> print(server.status()['mindsdb_version'])
+
+        :return: server status info
+        """
+        return self.api.status()
+
     def __repr__(self):
         return f'{self.__class__.__name__}({self.api.url})'
 

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -178,9 +178,10 @@ class BaseFlow:
 
 class Test(BaseFlow):
 
+    @patch('requests.Session.get')
     @patch('requests.Session.put')
     @patch('requests.Session.post')
-    def test_flow(self, mock_post, mock_put):
+    def test_flow(self, mock_post, mock_put, mock_get):
 
         server = mindsdb_sdk.connect(login='a@b.com')
 
@@ -188,6 +189,11 @@ class Test(BaseFlow):
         call_args = mock_post.call_args
         assert call_args[0][0] == 'https://cloud.mindsdb.com/cloud/login'
         assert call_args[1]['json']['email'] == 'a@b.com'
+
+        # server status
+        server.status()
+        call_args = mock_get.call_args
+        assert call_args[0][0] == 'https://cloud.mindsdb.com/api/status'
 
         # --------- databases -------------
         response_mock(mock_post, pd.DataFrame([{'NAME': 'db1'}]))


### PR DESCRIPTION

Changes:
- show server info. Example to show mindsdb version for local instance
```python
print(server.status()['mindsdb_version'])
```

Fixes: #85