### PR TITLE
Remove 'Database is not defined' on 'create model'

### DIFF
--- a/mindsdb_sdk/models.py
+++ b/mindsdb_sdk/models.py
@@ -463,8 +463,6 @@ class Models(CollectionBase):
             targets = [Identifier(predict)]
         else:
             targets = None
-        if database is None:
-            raise RuntimeError('Database is not defined')
 
         ast_query = CreatePredictor(
             name=Identifier(name),

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -844,6 +844,19 @@ class CustomPredictor():
             f'CREATE PREDICTOR m2 FROM {database.name} (select * from t2) PREDICT price'
         )
 
+        # create without database
+        model = project.models.create(
+            'm2',
+            predict='response',
+            engine='openai',
+            options={'prompt': 'make up response'},
+        )
+
+        check_sql_call(
+            mock_post,
+            f'CREATE PREDICTOR m2 PREDICT response USING prompt="make up response", `engine`="openai"'
+        )
+
         assert model.name == 'm2'
         self.check_model(model, database)
 


### PR DESCRIPTION
Fixes:
- Allow create model without database
- 
Fixes: #92
