### PR TITLE
LAST support

### DIFF
--- a/mindsdb_sdk/jobs.py
+++ b/mindsdb_sdk/jobs.py
@@ -98,9 +98,15 @@ class Jobs(CollectionBase):
         else:
             raise RuntimeError("Several jobs with the same name")
 
-    def create(self, name: str, query_str: str,
-                   start_at: dt.datetime = None, end_at: dt.datetime = None,
-                   repeat_str: str = None) -> Union[Job, None]:
+    def create(
+            self,
+            name: str,
+            query_str: str,
+            start_at: dt.datetime = None,
+            end_at: dt.datetime = None,
+            repeat_str: str = None,
+            repeat_min: int = None,
+        ) -> Union[Job, None]:
         """
         Create new job in project and return it.
 
@@ -114,6 +120,7 @@ class Jobs(CollectionBase):
         :param start_at: datetime, first start of job,
         :param end_at: datetime, when job have to be stopped,
         :param repeat_str: str, optional, how to repeat job (e.g. '1 hour', '2 weeks', '3 min')
+        :param repeat_min: int, optional, period to repeat the job in minutes
         :return: Job object or None
         """
 
@@ -126,6 +133,10 @@ class Jobs(CollectionBase):
             end_str = end_at.strftime("%Y-%m-%d %H:%M:%S")
         else:
             end_str = None
+
+        if repeat_min is not None:
+            repeat_str = f'{repeat_min} minutes'
+
         ast_query = CreateJob(
             name=Identifier(name),
             query_str=query_str,

--- a/mindsdb_sdk/tables.py
+++ b/mindsdb_sdk/tables.py
@@ -72,6 +72,14 @@ class Table(Query):
         First call returns nothing
         The next calls return new records since previous call (where value of track_column is greater)
 
+        Example:
+
+        >>> query = con.databases.my_db.tables.sales.filter(type='house').track('created_at')
+        >>> # first call returns no records
+        >>> df = query.fetch()
+        >>> # second call returns rows with created_at is greater since previous fetch
+        >>> df = query.fetch()
+
         :param column: column to track new data from table.
         :return: Table object
         """

--- a/mindsdb_sdk/utils/sql.py
+++ b/mindsdb_sdk/utils/sql.py
@@ -1,19 +1,23 @@
-from mindsdb_sql.parser.ast import *
+from mindsdb_sql.parser.ast import BinaryOperation, Identifier, Constant
 
 
 def dict_to_binary_op(filters):
     where = None
     for name, value in filters.items():
-        where1 = BinaryOperation('=', args=[Identifier(name), Constant(value)])
-        if where is None:
-            where = where1
-        else:
-            where = BinaryOperation(
-                'and',
-                args=[where, where1]
-            )
+        condition = BinaryOperation('=', args=[Identifier(name), Constant(value)])
+
+        where = add_condition(where, condition)
+
     return where
 
 
+def add_condition(where, condition):
+    if where is None:
+        return condition
+    else:
+        return BinaryOperation(
+            'and',
+            args=[where, condition]
+        )
 
 

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1044,14 +1044,14 @@ class CustomPredictor():
         project.jobs.create(
             name='job2',
             query_str='retrain m1',
-            repeat_str='1 min',
+            repeat_min=1,
             start_at=dt.datetime(2025, 2, 5, 11, 22),
             end_at=dt.date(2030, 1, 2)
         )
 
         check_sql_call(
             mock_post,
-            f"CREATE JOB job2 (retrain m1) START '2025-02-05 11:22:00' END '2030-01-02 00:00:00' EVERY 1 min",
+            f"CREATE JOB job2 (retrain m1) START '2025-02-05 11:22:00' END '2030-01-02 00:00:00' EVERY 1 minutes",
             call_stack_num=-2
         )
 

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -169,11 +169,15 @@ class BaseFlow:
     def check_table(self, table, mock_post):
         response_mock(mock_post, pd.DataFrame([{'x': 'a'}]))
 
-        table = table.filter(a=3, b='2')
-        table = table.limit(3)
-        table.fetch()
-        str(table)
-        check_sql_call(mock_post, f'SELECT * FROM {table.name} WHERE a = 3 AND b = \'2\' LIMIT 3')
+        table2 = table.filter(a=3, b='2').limit(3)
+        table2.fetch()
+        str(table2)
+        check_sql_call(mock_post, f'SELECT * FROM {table2.name} WHERE a = 3 AND b = \'2\' LIMIT 3')
+
+        # last
+        table2 = table.filter(a=3).track('type')
+        table2.fetch()
+        check_sql_call(mock_post, f'SELECT * FROM {table2.name} WHERE a = 3 AND type > last')
 
 
 class Test(BaseFlow):


### PR DESCRIPTION
Added support of 'LAST' for table and view. 

Example:
```python
query = con.databases.my_db.tables.sales.filter(type='house').track('created_at')

# first call returns no records
df = query.fetch()

# second call returns rows with created_at is greater since previous fetch
df = query.fetch()
```