### PR TITLE
Job supports SDK comands

### DIFF
--- a/mindsdb_sdk/connectors/rest_api.py
+++ b/mindsdb_sdk/connectors/rest_api.py
@@ -5,7 +5,7 @@ import io
 import requests
 import pandas as pd
 
-from .. import __about__
+from mindsdb_sdk import __about__
 
 
 def _try_relogin(fnc):
@@ -73,7 +73,11 @@ class RestAPI:
         _raise_for_status(r)
 
     @_try_relogin
-    def sql_query(self, sql, database='mindsdb', lowercase_columns=False):
+    def sql_query(self, sql, database=None, lowercase_columns=False):
+
+        if database is None:
+            # it means the database is included in query
+            database = 'mindsdb'
         url = self.url + '/api/sql/query'
         r = self.session.post(url, json={
             'query': sql,

--- a/mindsdb_sdk/jobs.py
+++ b/mindsdb_sdk/jobs.py
@@ -38,7 +38,10 @@ class Job:
 
     def __enter__(self):
         if self._create_callback is None:
-            raise RuntimeError('It can not be used to create context')
+            raise ValueError("The job is already created and can't be used to create context."
+                               " To be able to use context: create job without 'query_str' parameter: "
+                               "\n>>> with con.jobs.create('j1') as job:"
+                               "\n>>>    job.add_query(...)")
         set_saving(f'job-{self.name}')
 
         return self
@@ -47,7 +50,7 @@ class Job:
         set_saving(None)
         if type is None:
             if len(self._queries) == 0:
-                raise RuntimeError('No queries were added to job')
+                raise ValueError('No queries were added to job')
 
             query_str = '; '.join(self._queries)
 
@@ -79,7 +82,7 @@ class Job:
 
             query = query.sql
         elif not isinstance(query, str):
-            raise RuntimeError(f'Unable to use add this object as a query: {query}. Try to use sql string instead')
+            raise ValueError(f'Unable to use add this object as a query: {query}. Try to use sql string instead')
         self._queries.append(query)
 
     def get_history(self) -> pd.DataFrame:
@@ -164,7 +167,7 @@ class Jobs(CollectionBase):
         Usage options:
 
         Option 1: to use string query
-        All job tasks could be passed as string with sql queries. Job is created emmideiately
+        All job tasks could be passed as string with sql queries. Job is created immediately
 
         >>> job = con.jobs.create('j1', query_str='retrain m1; show models', repeat_min=1):
 

--- a/mindsdb_sdk/jobs.py
+++ b/mindsdb_sdk/jobs.py
@@ -1,23 +1,32 @@
 import datetime as dt
 from typing import Union, List
 
+
 import pandas as pd
 
 from mindsdb_sql.parser.dialects.mindsdb import CreateJob, DropJob
 from mindsdb_sql.parser.ast import Identifier, Star, Select
 
+from mindsdb_sdk.query import Query
 from mindsdb_sdk.utils.sql import dict_to_binary_op
 from mindsdb_sdk.utils.objects_collection import CollectionBase
+from mindsdb_sdk.utils.context import set_saving
 
 
 class Job:
-    def __init__(self, project, data):
+    def __init__(self, project, name, data=None, create_callback=None):
         self.project = project
+        self.name = name
         self.data = data
-        self._update(data)
+
+        self.query_str = None
+        if data is not None:
+            self._update(data)
+        self._queries = []
+        self._create_callback = create_callback
 
     def _update(self, data):
-        self.name = data['name']
+        # self.name = data['name']
         self.query_str = data['query']
         self.start_at = data['start_at']
         self.end_at = data['end_at']
@@ -27,12 +36,51 @@ class Job:
     def __repr__(self):
         return f"{self.__class__.__name__}({self.name}, query='{self.query_str}')"
 
+    def __enter__(self):
+        if self._create_callback is None:
+            raise RuntimeError('It can not be used to create context')
+        set_saving(f'job-{self.name}')
+
+        return self
+
+    def __exit__(self, type, value, traceback):
+        set_saving(None)
+        if type is None:
+            if len(self._queries) == 0:
+                raise RuntimeError('No queries were added to job')
+
+            query_str = '; '.join(self._queries)
+
+            self._create_callback(query_str)
+
+            self.refresh()
+
     def refresh(self):
         """
         Retrieve job data from mindsdb server
         """
         job = self.project.get_job(self.name)
         self._update(job.data)
+
+    def add_query(self, query: Union[Query, str]):
+        """
+        Add a query to job. Method is used in context of the job
+
+        >>> with con.jobs.create('j1') as job:
+        >>>    job.add_query(table1.insert(table2))
+
+        :param query: string or Query object. Query.database should be emtpy or the same as job's project
+        """
+        if isinstance(query, Query):
+
+            if query.database is not None and query.database != self.project.name:
+                # we can't execute this query in jobs project
+                raise ValueError(f"Wrong query database: {query.database}. You could try to use sql string instead")
+
+            query = query.sql
+        elif not isinstance(query, str):
+            raise RuntimeError(f'Unable to use add this object as a query: {query}. Try to use sql string instead')
+        self._queries.append(query)
 
     def get_history(self) -> pd.DataFrame:
         """
@@ -69,7 +117,7 @@ class Jobs(CollectionBase):
         df = df.rename(columns=cols_map)
 
         return [
-            Job(self.project, item)
+            Job(self.project, item.pop('name'), item)
             for item in df.to_dict('records')
         ]
 
@@ -101,7 +149,7 @@ class Jobs(CollectionBase):
     def create(
             self,
             name: str,
-            query_str: str,
+            query_str: str = None,
             start_at: dt.datetime = None,
             end_at: dt.datetime = None,
             repeat_str: str = None,
@@ -113,7 +161,25 @@ class Jobs(CollectionBase):
         If it is not possible (job executed and not accessible anymore):
            return None
 
-        More info: https://docs.mindsdb.com/sql/create/jobs
+        Usage options:
+
+        Option 1: to use string query
+        All job tasks could be passed as string with sql queries. Job is created emmideiately
+
+        >>> job = con.jobs.create('j1', query_str='retrain m1; show models', repeat_min=1):
+
+        Option 2: to use 'with' block.
+        It allows to pass sdk commands to job tasks.
+        Not all sdk commands could be accepted here,
+         only those which are converted in to sql in sdk and sent to /query endpoint
+        Adding query sql string is accepted as well
+        Job will be created after exit from 'with' block
+
+        >>> with con.jobs.create('j1', repeat_min=1) as job:
+        >>>    job.add_query(table1.insert(table2))
+        >>>    job.add_query('retrain m1')  # using string
+
+        More info about jobs: https://docs.mindsdb.com/sql/create/jobs
 
         :param name: name of the job
         :param query_str: str, job's query (or list of queries with ';' delimiter) which job have to execute
@@ -137,20 +203,30 @@ class Jobs(CollectionBase):
         if repeat_min is not None:
             repeat_str = f'{repeat_min} minutes'
 
-        ast_query = CreateJob(
-            name=Identifier(name),
-            query_str=query_str,
-            start_str=start_str,
-            end_str=end_str,
-            repeat_str=repeat_str
-        )
+        def _create_callback(query):
+            ast_query = CreateJob(
+                name=Identifier(name),
+                query_str=query,
+                start_str=start_str,
+                end_str=end_str,
+                repeat_str=repeat_str
+            )
 
-        self.api.sql_query(ast_query.to_string(), database=self.project.name)
+            self.api.sql_query(ast_query.to_string(), database=self.project.name)
 
-        # job can be executed and remove it is not repeatable
-        jobs = self._list(name)
-        if len(jobs) == 1:
-            return jobs[0]
+        if query_str is None:
+            # allow to create context with job
+            job = Job(self.project, name, create_callback=_create_callback)
+            return job
+        else:
+            # create it
+            _create_callback(query_str)
+
+            # job can be executed and remove it is not repeatable
+            jobs = self._list(name)
+            if len(jobs) == 1:
+                return jobs[0]
+
 
     def drop(self, name: str):
         """

--- a/mindsdb_sdk/tables.py
+++ b/mindsdb_sdk/tables.py
@@ -9,6 +9,7 @@ from mindsdb_sql.parser.ast import Select, Star, Identifier, Constant, Delete, I
 
 from mindsdb_sdk.utils.sql import dict_to_binary_op, add_condition, query_to_native_query
 from mindsdb_sdk.utils.objects_collection import CollectionBase
+from mindsdb_sdk.utils.context import is_saving
 
 from .query import Query
 
@@ -159,7 +160,11 @@ class Table(Query):
             where=dict_to_binary_op(kwargs)
         )
         sql = ast_query.to_string()
-        self.api.sql_query(sql, 'mindsdb')
+
+        if is_saving():
+            return Query(self, sql)
+
+        self.api.sql_query(sql)
 
     def update(self, values: Union[dict, Query], on: list = None, filters: dict = None):
         '''
@@ -217,6 +222,11 @@ class Table(Query):
             sql = ast_query.to_string()
         else:
             raise NotImplementedError
+
+        if is_saving():
+            return Query(self, sql)
+
+        self.api.sql_query(sql)
 
 
 class Tables(CollectionBase):

--- a/mindsdb_sdk/utils/context.py
+++ b/mindsdb_sdk/utils/context.py
@@ -1,0 +1,25 @@
+from contextvars import ContextVar
+
+context_storage = ContextVar('create_context')
+
+
+def set_context(name, value):
+    data = context_storage.get({})
+    data[name] = value
+
+    context_storage.set(data)
+
+
+def get_context(name):
+
+    data = context_storage.get({})
+    return data.get(name)
+
+
+def set_saving(name):
+    set_context('saving', name)
+
+
+def is_saving():
+    return get_context('saving') is not None
+

--- a/mindsdb_sdk/utils/context.py
+++ b/mindsdb_sdk/utils/context.py
@@ -3,23 +3,44 @@ from contextvars import ContextVar
 context_storage = ContextVar('create_context')
 
 
-def set_context(name, value):
+def set_context(name: str, value: str):
+    """
+    Set context value to variable
+
+    :param name: variable name
+    :param value: variable value
+    """
     data = context_storage.get({})
     data[name] = value
 
     context_storage.set(data)
 
 
-def get_context(name):
+def get_context(name: str) -> str:
+    """
+    Get context value fom variable
+
+    :param name: variable name
+    :return: variable value
+    """
 
     data = context_storage.get({})
     return data.get(name)
 
 
-def set_saving(name):
+def set_saving(name: str):
+    """
+    Set name of saving object to context
+
+    :param name: namve of the object
+    """
     set_context('saving', name)
 
 
-def is_saving():
+def is_saving() -> bool:
+    """
+    Returns true if object is saved at the moment
+    """
+
     return get_context('saving') is not None
 

--- a/mindsdb_sdk/utils/sql.py
+++ b/mindsdb_sdk/utils/sql.py
@@ -1,5 +1,5 @@
-from mindsdb_sql.parser.ast import BinaryOperation, Identifier, Constant
-
+from mindsdb_sql.parser.ast import BinaryOperation, Identifier, Constant, Select, Star, NativeQuery
+from mindsdb_sdk.query import Query
 
 def dict_to_binary_op(filters):
     where = None
@@ -21,3 +21,11 @@ def add_condition(where, condition):
         )
 
 
+def query_to_native_query(query: Query):
+    return Select(
+        targets=[Star()],
+        from_table= NativeQuery(
+            integration=Identifier(query.database),
+            query=query.sql
+        )
+    )


### PR DESCRIPTION
Added alternative way to create job:

```python
with project.jobs.create(name='job2', repeat_min=1) as job:
      job.add_query(model.retrain())
      job.add_query(model.predict(database.tables.tbl1))
      job.add_query(kb.insert(database.tables.tbl1))
      job.add_query('show models') # use string
```

When 'with' block is used job is not created immediately, only at exit of this block.
Inside of this block we can add queries to job using `.add_query` method. It accepts string or Query object. 
To make it worked inside of this context block some SDK functions are switched to deferred mode: 
- instead of sending of query to /api/sql/query they started to return Query object which contains this query.
Not every SDK command can be used inside of 'job create' block:
- they have to use  /api/sql/query endpoint (it means they can be represented as SQL). What are not used SQL endpoint:
   - predict from dataframe
   - Agent, Skills (they use own http endpoints)  
- only part of the SDK function adapted to support it. 
  - Covered blocks: Knowledge bases, Models, Tables, Views, Queries,
  - Skipped blocks: Databases, Handlers, Jobs, ML_engines, Projects (it means they can't be manipulated inside of the job)
 
The old option is also possible:
```python
job = project.jobs.create(
      name='job2',
      query_str='retrain m1', # query as a string
      repeat_min=1
)
```