### PR TITLE
Support Authenticating With API Key

### DIFF
--- a/mindsdb_sdk/connect.py
+++ b/mindsdb_sdk/connect.py
@@ -6,13 +6,20 @@ DEFAULT_LOCAL_API_URL = 'http://127.0.0.1:47334'
 DEFAULT_CLOUD_API_URL = 'https://cloud.mindsdb.com'
 
 
-def connect(url: str = None, login: str = None, password: str = None, is_managed: bool = False, headers=None) -> Server:
+def connect(
+        url: str = None,
+        login: str = None,
+        password: str = None,
+        api_key: str = None,
+        is_managed: bool = False,
+        headers=None) -> Server:
     """
     Create connection to mindsdb server
 
     :param url: url to mindsdb server
     :param login: user login, for cloud version it contents email
     :param password: user password to login (for cloud version)
+    :param api_key: API key to authenticate (for cloud version)
     :param is_managed: whether or not the URL points to a managed instance
     :param headers: addtional headers to send with the connection, optional
     :return: Server object
@@ -29,8 +36,7 @@ def connect(url: str = None, login: str = None, password: str = None, is_managed
 
     Connect to cloud server
 
-    >>> con = mindsdb_sdk.connect(login='a@b.com', password='-')
-    >>> con = mindsdb_sdk.connect('https://cloud.mindsdb.com', login='a@b.com', password='-')
+    >>> con = mindsdb_sdk.connect('https://cloud.mindsdb.com', api_key='-')
 
     Connect to MindsDB pro
 
@@ -45,6 +51,6 @@ def connect(url: str = None, login: str = None, password: str = None, is_managed
             # is local
             url = DEFAULT_LOCAL_API_URL
 
-    api = RestAPI(url, login, password, is_managed, headers=headers)
+    api = RestAPI(url, login, password, api_key, is_managed, headers=headers)
 
     return Server(api)

--- a/mindsdb_sdk/connectors/rest_api.py
+++ b/mindsdb_sdk/connectors/rest_api.py
@@ -34,19 +34,22 @@ def _raise_for_status(response):
 
 
 class RestAPI:
-    def __init__(self, url=None, login=None, password=None, is_managed=False, headers=None):
+    def __init__(self, url=None, login=None, password=None, api_key=None, is_managed=False, headers=None):
 
         self.url = url
         self.username = login
         self.password = password
+        self.api_key = api_key
         self.is_managed = is_managed
         self.session = requests.Session()
 
         self.session.headers['User-Agent'] = f'python-sdk/{__about__.__version__}'
-
         if headers is not None:
             self.session.headers.update(headers)
-
+        if self.api_key is not None:
+            # Authenticate with API key instead of logging in, if present.
+            self.session.headers['X-Api-Key'] = self.api_key
+            return
         if login is not None:
             self.login()
 


### PR DESCRIPTION
Now that our gateway supports authenticating with an `X-Api-Key` header, we can authenticate to the SDK using an API key instead of the legacy username + password combination.

Example:

```python
con = mindsdb_sdk.connect('https://cloud.mindsdb.com', api_key=...)`
```