### PR TITLE
Bump SDK Version to 2.3.0

### DIFF
--- a/mindsdb_sdk/__about__.py
+++ b/mindsdb_sdk/__about__.py
@@ -1,6 +1,6 @@
 __title__ = 'mindsdb_sdk'
 __package_name__ = 'mindsdb_sdk'
-__version__ = '2.2.1'
+__version__ = '2.3.0'
 __description__ = "MindsDB Python SDK, provides an SDK to use a remote mindsdb instance"
 __email__ = "jorge@mindsdb.com"
 __author__ = 'MindsDB Inc'


### PR DESCRIPTION
Now that we've released an agents overhaul, we should bump the SDK version for release.