### PR TITLE
Don't Use Agent Retrieval Mode by Default

### DIFF
--- a/mindsdb_sdk/agents.py
+++ b/mindsdb_sdk/agents.py
@@ -364,7 +364,7 @@ class Agents(CollectionBase):
             'prompt_template': 'Answer the user"s question in a helpful way: {{question}}',
             # Use GPT-4 by default.
             'provider': 'openai',
-            'model_name': 'gpt-3.5-turbo'
+            'model_name': 'gpt-4'
         }
         if model is None:
             return self.models.create(


### PR DESCRIPTION
If we create an agent with `retrieval` mode and don't pass in embedding model arguments, we will create a default embedding model (for RAG i.e. retrieval) each time, which can take a few seconds.

Instead, the default should be to _not_ use retrieval for agents.