### PR TITLE
Don't create model automatically for agent

### DIFF
--- a/mindsdb_sdk/agents.py
+++ b/mindsdb_sdk/agents.py
@@ -4,7 +4,6 @@ from urllib.parse import urlparse
 from uuid import uuid4
 import datetime
 import json
-import pandas as pd
 
 from mindsdb_sdk.databases import Databases
 from mindsdb_sdk.knowledge_bases import KnowledgeBase, KnowledgeBases
@@ -383,50 +382,14 @@ class Agents(CollectionBase):
         agent.skills.append(database_sql_skill)
         self.update(agent.name, agent)
 
-    def _create_ml_engine_if_not_exists(self, name: str = 'langchain'):
-        try:
-            _ = self.ml_engines.get('langchain')
-        except Exception:
-            # Create the engine if it doesn't exist.
-            _ = self.ml_engines.create('langchain', handler='langchain')
-
-    def _create_model_if_not_exists(self, name: str, model: Union[Model, dict, str]) -> str:
-        # Create langchain engine if it doesn't exist.
-        self._create_ml_engine_if_not_exists()
-        # Create a default model if it doesn't exist.
-        default_model_params = {
-            'predict': 'answer',
-            'engine': 'langchain',
-            'prompt_template': 'Answer the user"s question in a helpful way: {{question}}',
-            # Use GPT-4 by default.
-            'provider': 'openai',
-            'model_name': 'gpt-4'
-        }
-
-        if isinstance(model, dict):
-            default_model_params.update(model)
-            # Create model with passed in params.
-            return self.models.create(
-                f'{name}_default_model',
-                **default_model_params
-            ).name
-
-        if model is None:
-            # Create model with default params.
-            return _DEFAULT_LLM_MODEL
-
-        if isinstance(model, Model):
-            return model.name
-
-        return model
-
     def create(
             self,
             name: str,
             model: Union[Model, dict, str] = None,
             provider: str = None,
             skills: List[Union[Skill, str]] = None,
-            params: dict = None) -> Agent:
+            params: dict = None,
+            **kwargs) -> Agent:
         """
         Create new agent and return it
 
@@ -449,7 +412,15 @@ class Agents(CollectionBase):
             _ = self.skills.create(skill.name, skill.type, skill.params)
             skill_names.append(skill.name)
 
-        model = self._create_model_if_not_exists(name, model)
+        if model is None:
+            model = _DEFAULT_LLM_MODEL
+
+        if params is None:
+            params = {}
+        params.update(kwargs)
+
+        if 'prompt_template' not in params:
+            params['prompt_template'] = 'Answer the user"s question in a helpful way: {{question}}'
 
         data = self.api.create_agent(self.project, name, model, provider, skill_names, params)
         return Agent.from_json(data, self)

--- a/mindsdb_sdk/agents.py
+++ b/mindsdb_sdk/agents.py
@@ -412,15 +412,18 @@ class Agents(CollectionBase):
             _ = self.skills.create(skill.name, skill.type, skill.params)
             skill_names.append(skill.name)
 
-        if model is None:
-            model = _DEFAULT_LLM_MODEL
-
         if params is None:
             params = {}
         params.update(kwargs)
 
         if 'prompt_template' not in params:
             params['prompt_template'] = 'Answer the user"s question in a helpful way: {{question}}'
+
+        if model is None:
+            model = _DEFAULT_LLM_MODEL
+        elif isinstance(model, Model):
+            model = model.name
+            provider = 'mindsdb'
 
         data = self.api.create_agent(self.project, name, model, provider, skill_names, params)
         return Agent.from_json(data, self)

--- a/mindsdb_sdk/agents.py
+++ b/mindsdb_sdk/agents.py
@@ -13,6 +13,7 @@ from mindsdb_sdk.skills import Skill, Skills
 from mindsdb_sdk.utils.objects_collection import CollectionBase
 
 _DEFAULT_LLM_MODEL = 'gpt-4o'
+_DEFAULT_LLM_PROMPT = 'Answer the user"s question in a helpful way: {{question}}'
 
 class AgentCompletion:
     """Represents a full MindsDB agent completion"""
@@ -417,7 +418,7 @@ class Agents(CollectionBase):
         params.update(kwargs)
 
         if 'prompt_template' not in params:
-            params['prompt_template'] = 'Answer the user"s question in a helpful way: {{question}}'
+            params['prompt_template'] = _DEFAULT_LLM_PROMPT
 
         if model is None:
             model = _DEFAULT_LLM_MODEL

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1327,7 +1327,6 @@ class TestAgents():
         }
         responses_mock(mock_post, [
             # ML Engine get (SQL post for SHOW ML_ENGINES)
-            pd.DataFrame([{'name': 'langchain', 'handler': 'langchain', 'connection_data': {}}]),
             data
         ])
         responses_mock(mock_get, [
@@ -1344,15 +1343,18 @@ class TestAgents():
             params={'k1': 'v1'}
         )
         # Check API call.
-        assert len(mock_post.call_args_list) == 2
+        assert len(mock_post.call_args_list) == 1
         assert mock_post.call_args_list[-1][0][0] == f'{DEFAULT_LOCAL_API_URL}/api/projects/mindsdb/agents'
         assert mock_post.call_args_list[-1][1]['json'] == {
             'agent': {
                 'name': 'test_agent',
                 'model_name': 'm1',
                 'skills': ['test_skill'],
-                'params': {'k1': 'v1'},
-                'provider': None
+                'params': {
+                    'k1': 'v1',
+                    'prompt_template': 'Answer the user"s question in a helpful way: {{question}}'
+                },
+                'provider': 'mindsdb'
             }
         }
         expected_skill = SQLSkill('test_skill', ['test_table'], 'test_database', 'test_description')


### PR DESCRIPTION
After [decoupling agent](https://github.com/mindsdb/mindsdb/pull/9481) from langchain handler mindsdb langchain model is not required for agent. 
In this PR automatic model creation is removed. 

Agent can be used as:
```python
agent=connection.agents.create('my_agent', skills=['my_skill'], prompt_template='Answer the user input in a helpful way')

# or with default prompt template
agent=connection.agents.create('my_agent', skills=['my_skill'])
```

dependent on https://github.com/mindsdb/mindsdb/pull/9525