### PR TITLE
Fix completion streaming for agents and introduce quick response

### DIFF
--- a/examples/using_agents_with_streaming_with_retrieval.py
+++ b/examples/using_agents_with_streaming_with_retrieval.py
@@ -15,7 +15,19 @@ agent = con.agents.create(name=f'mindsdb_retrieval_agent_{model_name}_{uuid4().h
 agent.add_file('./data/tokaido-rulebook.pdf', 'rule book for the board game Tokaido')
 
 question = "what are the rules for the game takaido?"
-answer = agent.completion([{'question': question, 'answer': None}])
-print(answer.context)
-print(answer)
 
+# Stream the completion
+completion_stream = agent.completion_stream([{'question': question, 'answer': None}])
+
+# Process the streaming response
+full_response = ""
+for chunk in completion_stream:
+    print(chunk)  # Print the entire chunk for debugging
+    if isinstance(chunk, dict):
+        if 'output' in chunk:
+            full_response += chunk['output']
+    elif isinstance(chunk, str):
+        full_response += chunk
+
+print("\n\nFull response:")
+print(full_response)

--- a/mindsdb_sdk/agents.py
+++ b/mindsdb_sdk/agents.py
@@ -492,6 +492,10 @@ class Agents(CollectionBase):
                 _ = self.skills.create(skill.name, skill.type, skill.params)
             updated_skills.add(skill.name)
 
+            # Set mode to retrieval if any retrieval skill is added.
+            if skill.type == 'retrieval' and 'mode' not in updated_agent.params:
+                updated_agent.params['mode'] = 'retrieval'
+
         existing_agent = self.api.agent(self.project, name)
         existing_skills = set([s['name'] for s in existing_agent['skills']])
         skills_to_add = updated_skills.difference(existing_skills)

--- a/mindsdb_sdk/agents.py
+++ b/mindsdb_sdk/agents.py
@@ -492,10 +492,6 @@ class Agents(CollectionBase):
                 _ = self.skills.create(skill.name, skill.type, skill.params)
             updated_skills.add(skill.name)
 
-            # Set mode to retrieval if any retrieval skill is added.
-            if skill.type == 'retrieval' and 'mode' not in updated_agent.params:
-                updated_agent.params['mode'] = 'retrieval'
-
         existing_agent = self.api.agent(self.project, name)
         existing_skills = set([s['name'] for s in existing_agent['skills']])
         skills_to_add = updated_skills.difference(existing_skills)


### PR DESCRIPTION
Changed the model name from 'gpt-4' to 'gpt-4o' and introduced functionality to set the agent mode to 'retrieval' if any retrieval skill is added. Also, added a new example script demonstrating agent streaming responses with retrieval.


Depends on: https://github.com/mindsdb/mindsdb/pull/9576

Part of ML-104