### PR TITLE
Update model name and base URL in minds Text2SQL example

### DIFF
--- a/examples/using_database_mind_text2sql.py
+++ b/examples/using_database_mind_text2sql.py
@@ -8,11 +8,8 @@ import os
 # Load MindsDB API key from environment variable. or set it here.
 MINDSDB_API_KEY = os.getenv('MINDSDB_API_KEY')
 
-# Set the model name for mind to use
-model_name = 'gpt-4'
-
 # Set the base URL for the MindsDB LiteLLM proxy.
-base_url = 'https://ai.dev.mindsdb.com'
+base_url = 'https://llm.mdb.ai'
 
 
 # Connect to MindsDB LiteLLM proxy.
@@ -41,8 +38,7 @@ mind = create_mind(
     base_url= base_url,
     api_key= MINDSDB_API_KEY,
     name = f'my_house_data_mind_{uuid4().hex}',
-    data_source_configs=[pg_config],
-    model= model_name
+    data_source_configs=[pg_config]
 )
 
 # Actually pass in our tool to get a SQL completion.


### PR DESCRIPTION
Updated the model name from 'gpt-4' to 'gpt-4o' and changed the base URL for the MindsDB LiteLLM proxy. Also removed the model parameter from the instantiation of the database mind.