### PR TITLE
Get Hex of UUIDs for Naming

### DIFF
--- a/mindsdb_sdk/agents.py
+++ b/mindsdb_sdk/agents.py
@@ -306,14 +306,14 @@ class Agents(CollectionBase):
         if knowledge_base is not None:
             kb = self.knowledge_bases.get(knowledge_base)
         else:
-            kb_name = f'{name}_{filename_no_extension}_{uuid4()}_kb'
+            kb_name = f'{name}_{filename_no_extension}_{uuid4().hex}_kb'
             kb = self._create_default_knowledge_base(agent, kb_name)
 
         # Insert the entire file.
         kb.insert_files(all_filenames)
 
         # Make sure skill name is unique.
-        skill_name = f'{filename_no_extension}_retrieval_skill_{uuid4()}'
+        skill_name = f'{filename_no_extension}_retrieval_skill_{uuid4().hex}'
         retrieval_params = {
             'source': kb.name,
             'description': description,
@@ -361,14 +361,14 @@ class Agents(CollectionBase):
         if knowledge_base is not None:
             kb = self.knowledge_bases.get(knowledge_base)
         else:
-            kb_name = f'{name}_web_{uuid4()}_kb'
+            kb_name = f'{name}_web_{uuid4().hex}_kb'
             kb = self._create_default_knowledge_base(agent, kb_name)
 
         # Insert crawled webpage.
         kb.insert_webpages(urls, crawl_depth=crawl_depth, filters=filters)
 
         # Make sure skill name is unique.
-        skill_name = f'web_retrieval_skill_{uuid4()}'
+        skill_name = f'web_retrieval_skill_{uuid4().hex}'
         retrieval_params = {
             'source': kb.name,
             'description': description,
@@ -415,7 +415,7 @@ class Agents(CollectionBase):
                 raise ValueError(f'Table {t} does not exist in database {database}.')
 
         # Make sure skill name is unique.
-        skill_name = f'{database}_sql_skill_{uuid4()}'
+        skill_name = f'{database}_sql_skill_{uuid4().hex}'
         sql_params = {
             'database': database,
             'tables': tables,


### PR DESCRIPTION
The original generated `uuid4` IDs may contain `-` characters. We only want the hex string.