### PR TITLE
Use Lower Case Naming for File Upload & KB Creation

### DIFF
--- a/mindsdb_sdk/agents.py
+++ b/mindsdb_sdk/agents.py
@@ -290,8 +290,8 @@ class Agents(CollectionBase):
         filename_no_extension = ''
         all_filenames = []
         for file_path in file_paths:
-            filename = file_path.split('/')[-1]
-            filename_no_extension = filename.split('.')[0].lower()
+            filename = file_path.split('/')[-1].lower()
+            filename_no_extension = filename.split('.')[0]
             all_filenames.append(filename_no_extension)
             try:
                 _ = self.api.get_file_metadata(filename_no_extension)

--- a/mindsdb_sdk/agents.py
+++ b/mindsdb_sdk/agents.py
@@ -291,7 +291,7 @@ class Agents(CollectionBase):
         all_filenames = []
         for file_path in file_paths:
             filename = file_path.split('/')[-1]
-            filename_no_extension = filename.split('.')[0]
+            filename_no_extension = filename.split('.')[0].lower()
             all_filenames.append(filename_no_extension)
             try:
                 _ = self.api.get_file_metadata(filename_no_extension)
@@ -306,14 +306,14 @@ class Agents(CollectionBase):
         if knowledge_base is not None:
             kb = self.knowledge_bases.get(knowledge_base)
         else:
-            kb_name = f'{name.lower()}_{filename_no_extension.lower()}_{uuid4().hex}_kb'
+            kb_name = f'{name.lower()}_{filename_no_extension}_{uuid4().hex}_kb'
             kb = self._create_default_knowledge_base(agent, kb_name)
 
         # Insert the entire file.
         kb.insert_files(all_filenames)
 
         # Make sure skill name is unique.
-        skill_name = f'{filename_no_extension.lower()}_retrieval_skill_{uuid4().hex}'
+        skill_name = f'{filename_no_extension}_retrieval_skill_{uuid4().hex}'
         retrieval_params = {
             'source': kb.name,
             'description': description,

--- a/mindsdb_sdk/agents.py
+++ b/mindsdb_sdk/agents.py
@@ -306,14 +306,14 @@ class Agents(CollectionBase):
         if knowledge_base is not None:
             kb = self.knowledge_bases.get(knowledge_base)
         else:
-            kb_name = f'{name}_{filename_no_extension}_{uuid4().hex}_kb'
+            kb_name = f'{name.lower()}_{filename_no_extension.lower()}_{uuid4().hex}_kb'
             kb = self._create_default_knowledge_base(agent, kb_name)
 
         # Insert the entire file.
         kb.insert_files(all_filenames)
 
         # Make sure skill name is unique.
-        skill_name = f'{filename_no_extension}_retrieval_skill_{uuid4().hex}'
+        skill_name = f'{filename_no_extension.lower()}_retrieval_skill_{uuid4().hex}'
         retrieval_params = {
             'source': kb.name,
             'description': description,
@@ -361,7 +361,7 @@ class Agents(CollectionBase):
         if knowledge_base is not None:
             kb = self.knowledge_bases.get(knowledge_base)
         else:
-            kb_name = f'{name}_web_{uuid4().hex}_kb'
+            kb_name = f'{name.lower()}_web_{uuid4().hex}_kb'
             kb = self._create_default_knowledge_base(agent, kb_name)
 
         # Insert crawled webpage.

--- a/mindsdb_sdk/utils/mind.py
+++ b/mindsdb_sdk/utils/mind.py
@@ -95,6 +95,8 @@ def create_mind(
 
     url = f"{base_url.rstrip('/')}/minds"
     headers = {"Authorization": f"Bearer {api_key}"}
+    if data_source_configs is None:
+        data_source_configs = []
     payload = {
         "name": name,
         "data_source_configs": [d.model_dump() for d in data_source_configs],


### PR DESCRIPTION
File names & KB names could be implicitly renamed to lower case (since SQL does not differentiate between upper/lower for identifiers) on the backend. So we should just ensure the names are all lowercase before creation & upload.