### PR TITLE
Add provider field to agent update functionality

### DIFF
--- a/mindsdb_sdk/agents.py
+++ b/mindsdb_sdk/agents.py
@@ -514,6 +514,7 @@ class Agents(CollectionBase):
             self.project.name,
             name,
             updated_agent.name,
+            updated_agent.provider,
             updated_agent.model_name,
             list(skills_to_add),
             list(skills_to_remove),

--- a/mindsdb_sdk/connectors/rest_api.py
+++ b/mindsdb_sdk/connectors/rest_api.py
@@ -309,6 +309,7 @@ class RestAPI:
             project: str,
             name: str,
             updated_name: str,
+            updated_provider: str,
             updated_model: str,
             skills_to_add: List[str],
             skills_to_remove: List[str],
@@ -321,6 +322,7 @@ class RestAPI:
                 'agent': {
                     'name': updated_name,
                     'model_name': updated_model,
+                    'provider': updated_provider,
                     'skills_to_add': skills_to_add,
                     'skills_to_remove': skills_to_remove,
                     'params': updated_params

--- a/tests/test_sdk.py
+++ b/tests/test_sdk.py
@@ -1445,7 +1445,8 @@ class TestAgents():
                 'model_name': 'updated_model',
                 'skills_to_add': ['updated_skill'],
                 'skills_to_remove': [],
-                'params': {'k2': 'v2'}
+                'params': {'k2': 'v2'},
+                'provider': 'mindsdb'
             }
         }
 
@@ -1546,6 +1547,7 @@ class TestAgents():
                 'skills_to_add': [agent_update_json['agent']['skills_to_add'][0]],
                 'skills_to_remove': [],
                 'params': {},
+                'provider': 'mindsdb'
             }
         }
         assert agent_update_json == expected_agent_json
@@ -1613,6 +1615,7 @@ class TestAgents():
                 'skills_to_add':[agent_update_json['agent']['skills_to_add'][0]],
                 'skills_to_remove':[],
                 'params':{},
+                'provider': 'mindsdb'
             }
         }
         assert agent_update_json == expected_agent_json
@@ -1682,6 +1685,7 @@ class TestAgents():
                 'skills_to_add': [agent_update_json['agent']['skills_to_add'][0]],
                 'skills_to_remove': [],
                 'params': {'prompt_template': 'using mindsdb sqltoolbox'},
+                'provider': 'mindsdb'
             }
         }
         assert agent_update_json == expected_agent_json


### PR DESCRIPTION
Extended the update_agent method to include the updated_provider parameter in both the REST API connector and agents class. Updated an example script to demonstrate the use of the new provider field for creating and managing agents.

This is needed for vLLM